### PR TITLE
Compatibility update for Laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "illuminate/console": ">= 5.0.0",
         "illuminate/config": ">= 5.0.0",
         "illuminate/filesystem": ">= 5.0.0",
-        "karunais13/laravel-onesignal": "^1.0"
+        "berkayk/onesignal-laravel": "^2.4"
     },
     "require-dev" : {
         "phpunit/phpunit" : ">=4.0",
@@ -33,10 +33,10 @@
         "laravel": {
             "providers": [
                 "Karu\\NpNotification\\NpNotificationProvider",
-                "Karu\\OneSignal\\OneSignalServiceProvider"
+                "Berkayk\\OneSignal\\OneSignalServiceProvider"
             ],
             "aliases": {
-                "OneSignal" : "Karu\\OneSignal\\OneSignalFacade",
+                "OneSignal": "Berkayk\\OneSignal\\OneSignalFacade",
                 "NotificationHelper": "Karu\\NpNotification\\Facades\\NotificationFacade"
             }
         }


### PR DESCRIPTION
This PR updates the package to make it installable in Laravel 11 by modifying dependency constraints and adjusting incompatible packages.